### PR TITLE
Add persistent relational database storage with SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 *.log
 *.sql
 *.sqlite
+*.db
 
 # OS generated files #
 ######################

--- a/src/README.md
+++ b/src/README.md
@@ -6,20 +6,34 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Data persists across app restarts using SQLite
 
 ## Getting Started
 
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r ../requirements.txt
    ```
 
 2. Run the application:
 
    ```
-   python app.py
+   uvicorn app:app --reload
    ```
+
+## Database-backed mode
+
+The API now uses a relational SQLite database by default.
+
+- Default DB file: `src/activities.db`
+- Override location with `DATABASE_PATH`, for example:
+
+  ```
+  DATABASE_PATH=./school.db uvicorn app:app --reload
+  ```
+
+On first startup, the app creates the schema and seeds initial activity/student/registration data.
 
 3. Open your browser and go to:
    - API documentation: http://localhost:8000/docs
@@ -36,15 +50,17 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 The application uses a simple data model with meaningful identifiers:
 
-1. **Activities** - Uses activity name as identifier:
+1. **Activities**:
 
    - Description
    - Schedule
    - Maximum number of participants allowed
-   - List of student emails who are signed up
+   - Linked registrations
 
-2. **Students** - Uses email as identifier:
-   - Name
-   - Grade level
+2. **Students**:
+   - Email
 
-All data is stored in memory, which means data will be reset when the server restarts.
+3. **Registrations**:
+   - Activity-to-student relationship records
+
+Data is persisted in SQLite and survives server restarts.

--- a/src/app.py
+++ b/src/app.py
@@ -10,17 +10,19 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import sqlite3
+
+current_dir = Path(__file__).parent
+database_path = os.getenv("DATABASE_PATH", str(current_dir / "activities.db"))
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
 # Mount the static files directory
-current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
+SEED_ACTIVITIES = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -78,6 +80,105 @@ activities = {
 }
 
 
+def get_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(database_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def initialize_database() -> None:
+    with get_connection() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS activities (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT NOT NULL,
+                schedule TEXT NOT NULL,
+                max_participants INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS students (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT NOT NULL UNIQUE
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS registrations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                activity_id INTEGER NOT NULL,
+                student_id INTEGER NOT NULL,
+                UNIQUE(activity_id, student_id),
+                FOREIGN KEY(activity_id) REFERENCES activities(id) ON DELETE CASCADE,
+                FOREIGN KEY(student_id) REFERENCES students(id) ON DELETE CASCADE
+            )
+            """
+        )
+
+        existing_activity_count = conn.execute(
+            "SELECT COUNT(*) as count FROM activities"
+        ).fetchone()["count"]
+
+        if existing_activity_count == 0:
+            seed_database(conn)
+
+
+def seed_database(conn: sqlite3.Connection) -> None:
+    for activity_name, details in SEED_ACTIVITIES.items():
+        activity_cursor = conn.execute(
+            """
+            INSERT INTO activities (name, description, schedule, max_participants)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                activity_name,
+                details["description"],
+                details["schedule"],
+                details["max_participants"],
+            ),
+        )
+        activity_id = activity_cursor.lastrowid
+
+        for email in details["participants"]:
+            conn.execute(
+                "INSERT OR IGNORE INTO students (email) VALUES (?)",
+                (email,),
+            )
+            student_id = conn.execute(
+                "SELECT id FROM students WHERE email = ?",
+                (email,),
+            ).fetchone()["id"]
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO registrations (activity_id, student_id)
+                VALUES (?, ?)
+                """,
+                (activity_id, student_id),
+            )
+
+
+def fetch_activity(activity_name: str, conn: sqlite3.Connection) -> sqlite3.Row | None:
+    return conn.execute(
+        """
+        SELECT id, name, description, schedule, max_participants
+        FROM activities
+        WHERE name = ?
+        """,
+        (activity_name,),
+    ).fetchone()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    initialize_database()
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -85,48 +186,120 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    try:
+        with get_connection() as conn:
+            activity_rows = conn.execute(
+                """
+                SELECT id, name, description, schedule, max_participants
+                FROM activities
+                ORDER BY name
+                """
+            ).fetchall()
+
+            registrations = conn.execute(
+                """
+                SELECT r.activity_id, s.email
+                FROM registrations r
+                JOIN students s ON s.id = r.student_id
+                ORDER BY s.email
+                """
+            ).fetchall()
+
+            participants_by_activity: dict[int, list[str]] = {}
+            for registration in registrations:
+                participants_by_activity.setdefault(
+                    registration["activity_id"], []).append(registration["email"])
+
+            activities: dict[str, dict[str, str | int | list[str]]] = {}
+            for activity in activity_rows:
+                activities[activity["name"]] = {
+                    "description": activity["description"],
+                    "schedule": activity["schedule"],
+                    "max_participants": activity["max_participants"],
+                    "participants": participants_by_activity.get(activity["id"], []),
+                }
+
+            return activities
+    except sqlite3.Error:
+        raise HTTPException(status_code=500, detail="Database error while loading activities")
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    try:
+        with get_connection() as conn:
+            activity = fetch_activity(activity_name, conn)
+            if activity is None:
+                raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+            conn.execute("INSERT OR IGNORE INTO students (email) VALUES (?)", (email,))
+            student = conn.execute(
+                "SELECT id FROM students WHERE email = ?",
+                (email,),
+            ).fetchone()
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+            existing_registration = conn.execute(
+                """
+                SELECT id
+                FROM registrations
+                WHERE activity_id = ? AND student_id = ?
+                """,
+                (activity["id"], student["id"]),
+            ).fetchone()
 
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+            if existing_registration:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Student is already signed up"
+                )
+
+            conn.execute(
+                """
+                INSERT INTO registrations (activity_id, student_id)
+                VALUES (?, ?)
+                """,
+                (activity["id"], student["id"]),
+            )
+            return {"message": f"Signed up {email} for {activity_name}"}
+    except sqlite3.Error:
+        raise HTTPException(status_code=500, detail="Database error while signing up")
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    try:
+        with get_connection() as conn:
+            activity = fetch_activity(activity_name, conn)
+            if activity is None:
+                raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+            student = conn.execute(
+                "SELECT id FROM students WHERE email = ?",
+                (email,),
+            ).fetchone()
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
+            if student is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Student is not signed up for this activity"
+                )
 
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+            deletion = conn.execute(
+                """
+                DELETE FROM registrations
+                WHERE activity_id = ? AND student_id = ?
+                """,
+                (activity["id"], student["id"]),
+            )
+
+            if deletion.rowcount == 0:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Student is not signed up for this activity"
+                )
+
+            return {"message": f"Unregistered {email} from {activity_name}"}
+    except sqlite3.Error:
+        raise HTTPException(status_code=500, detail="Database error while unregistering")


### PR DESCRIPTION
## Summary
- Replace in-memory activity storage with relational SQLite persistence
- Add startup schema initialization and seed path for local development
- Keep existing activity list/sign-up/unregister endpoints backward-compatible
- Add database error handling responses
- Document DB-backed mode in README

## Files changed
- `src/app.py`
- `src/README.md`
- `.gitignore`

## Notes
- Default DB file is `src/activities.db`
- DB path can be overridden with `DATABASE_PATH`
